### PR TITLE
Fix lvalue required as unary '&' operand

### DIFF
--- a/src/mrb_mysql.c
+++ b/src/mrb_mysql.c
@@ -130,19 +130,19 @@ bind_params(mrb_state* mrb, MYSQL_STMT* stmt, int argc, mrb_value* argv, int col
       break;
     case MRB_TT_FIXNUM:
       params[i].buffer_type = MYSQL_TYPE_LONG;
-      params[i].buffer = &mrb_fixnum(argv[i]);
+      params[i].buffer = mrb_fixnum(argv[i]);
       break;
     case MRB_TT_FLOAT:
       params[i].buffer_type = MYSQL_TYPE_FLOAT;
-      params[i].buffer = &mrb_float(argv[i]);
+      params[i].buffer = mrb_float(argv[i]);
       break;
     case MRB_TT_TRUE:
       params[i].buffer_type = MYSQL_TYPE_TINY;
-      params[i].buffer = &mrb_fixnum(argv[i]);
+      params[i].buffer = mrb_fixnum(argv[i]);
       break;
     case MRB_TT_FALSE:
       params[i].buffer_type = MYSQL_TYPE_TINY;
-      params[i].buffer = &mrb_fixnum(argv[i]);
+      params[i].buffer = mrb_fixnum(argv[i]);
       break;
     default:
       return "invalid argument";

--- a/src/mrb_mysql.c
+++ b/src/mrb_mysql.c
@@ -130,19 +130,31 @@ bind_params(mrb_state* mrb, MYSQL_STMT* stmt, int argc, mrb_value* argv, int col
       break;
     case MRB_TT_FIXNUM:
       params[i].buffer_type = MYSQL_TYPE_LONG;
-      params[i].buffer = mrb_fixnum(argv[i]);
+      {
+          mrb_int value = mrb_fixnum(argv[i]);
+          params[i].buffer = &value;
+      }
       break;
     case MRB_TT_FLOAT:
       params[i].buffer_type = MYSQL_TYPE_FLOAT;
-      params[i].buffer = mrb_float(argv[i]);
+      {
+          mrb_float value = mrb_float(argv[i]);
+          params[i].buffer = &value;
+      }
       break;
     case MRB_TT_TRUE:
       params[i].buffer_type = MYSQL_TYPE_TINY;
-      params[i].buffer = mrb_fixnum(argv[i]);
+      {
+          mrb_int value = mrb_fixnum(argv[i]);
+          params[i].buffer = &value;
+      }
       break;
     case MRB_TT_FALSE:
       params[i].buffer_type = MYSQL_TYPE_TINY;
-      params[i].buffer = mrb_fixnum(argv[i]);
+      {
+          mrb_int value = mrb_fixnum(argv[i]);
+          params[i].buffer = &value;
+      }
       break;
     default:
       return "invalid argument";


### PR DESCRIPTION
- env
    - Ubuntu 24.04.1 LTS
    - nginx-1.24.0
    - ruby 3.1.6p260 

```
/root/nginx/build/nginx-1.24.0/debian/modules/ngx_mruby/mruby/build/repos/host/mruby-mysql/src/mrb_mysql.c:133:26: error: lvalue required as unary '&' operand
  133 |       params[i].buffer = &mrb_fixnum(argv[i]);
      |                          ^
/root/nginx/build/nginx-1.24.0/debian/modules/ngx_mruby/mruby/build/repos/host/mruby-mysql/src/mrb_mysql.c:137:26: error: lvalue required as unary '&' operand
  137 |       params[i].buffer = &mrb_float(argv[i]);
      |                          ^
/root/nginx/build/nginx-1.24.0/debian/modules/ngx_mruby/mruby/build/repos/host/mruby-mysql/src/mrb_mysql.c:141:26: error: lvalue required as unary '&' operand
  141 |       params[i].buffer = &mrb_fixnum(argv[i]);
      |                          ^
/root/nginx/build/nginx-1.24.0/debian/modules/ngx_mruby/mruby/build/repos/host/mruby-mysql/src/mrb_mysql.c:145:26: error: lvalue required as unary '&' operand
  145 |       params[i].buffer = &mrb_fixnum(argv[i]);
      |                          ^
rake aborted!
```

I encountered the above build error, so I’ll fix it.